### PR TITLE
出力が文字列になっているバグを修正

### DIFF
--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -17,7 +17,7 @@ class PapersController < ApplicationController
     def all
         @papers = Paper.all
 
-        render :json => {:papers => @papers.to_json(:include => [:authors, :keywords])}
+        render :json => @papers.to_json(:include => [:authors, :keywords])
     end
 
     private


### PR DESCRIPTION
## 現状
- 出力がjson形式ではなくjson形式を文字列エンコーディングしたものになっていた

## 望ましい状態
- 出力はjson形式で返ってきて欲しい

## 原因
- なんか2回to_jsonを回していた

## 対応
- 上記原因を潰した