### PR TITLE
翻訳の挙動を変更する

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -61,6 +61,9 @@ class SearchController < ApplicationController
                 author_names.push(author_name)
             end
 
+            abstract.gsub!("\n", " ")
+            title.gsub!("\n", " ")
+
             # Paperモデルへの保存
             ## PaperがDB上に既に存在するかどうか確認
             paper = Paper.find_by(:arxiv_id => arxiv_id)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -21,23 +21,6 @@ class SearchController < ApplicationController
         render(json: papers)
     end
 
-    private
-    # Google Translateで翻訳する関数
-    def translate(content)
-      url = URI.parse('https://www.googleapis.com/language/translate/v2')
-      params = {
-        q: content,
-        target: "ja", # 翻訳したい言語
-        source: "en", # 翻訳する言語の種類
-        key: ENV["GOOGLE_CLOUD_API_KEY"]
-      }
-      url.query = URI.encode_www_form(params)
-      res = Net::HTTP.get_response(url)
-      json = res.body
-
-      return JSON.parse(json)["data"]["translations"].first["translatedText"]
-    end
-
     # arXiv APIから取得したXMLを解析してPaperモデルの配列を返す関数
     def parseXML(xmlString)
         # 返されるPaperの配列の準備
@@ -47,10 +30,8 @@ class SearchController < ApplicationController
         doc = REXML::Document.new(xmlString)
         doc.elements.each('//entry') do |e|
             title = e.elements['title'] ? e.elements['title'].text : ''
-            title_ja = translate(title)
             arxiv_id = e.elements['id'] ? e.elements['id'].text : ''
             abstract = e.elements['summary'] ? e.elements['summary'].text : ''
-            abstract_ja = translate(abstract)
             url = e.elements['link[@type="text/html"]'] ? e.elements['link[@type="text/html"]'].attributes['href'] : ''
             url_pdf = e.elements['link[@type="application/pdf"]'] ? e.elements['link[@type="application/pdf"]'].attributes['href'] : ''
             published_at = e.elements['published'] ? e.elements['published'].text : ''
@@ -69,7 +50,7 @@ class SearchController < ApplicationController
             paper = Paper.find_by(:arxiv_id => arxiv_id)
             if paper.nil? then
               ## PaperがDBに存在しなければ保存してpaper変数を更新
-              paper = Paper.create!(title: title, title_ja: title_ja, url: url, pdf_url: url_pdf, journal: journal, abstract: abstract, abstract_ja: abstract_ja, arxiv_id: arxiv_id, published_at: DateTime.parse(published_at))
+              paper = Paper.create!(title: title, url: url, pdf_url: url_pdf, journal: journal, abstract: abstract, arxiv_id: arxiv_id, published_at: DateTime.parse(published_at))
               ## Authorsの保存
               author_names.map do |author_name|
                 paper.authors.create!(name: author_name)

--- a/app/controllers/translate_controller.rb
+++ b/app/controllers/translate_controller.rb
@@ -1,0 +1,49 @@
+require 'net/https'
+require 'uri'
+
+class TranslateController < ApplicationController
+    def get
+        text = URI.encode_www_form_component(params['text'])
+        uri_str = "https://script.google.com/macros/s/AKfycbxCeACoPPfC8stClMomoRepp36ytKFT7lkQ8CkFy5bMwd0jiDQ/exec?text=#{text}"
+        response = fetch(uri_str)
+
+        id = params['paper']
+        paper = Paper.find(id)
+        type = params['type']
+
+        case type
+        when "title"
+            paper.update!(title_ja: JSON.parse(response.body)["text"])
+        when "abstract"
+            paper.update!(abstract_ja: JSON.parse(response.body)["text"])
+        else
+        end
+
+        render(json: JSON.parse(response.body))
+        return
+    end
+
+    private
+    def fetch(uri_str, limit = 10)
+        # You should choose better exception.
+        raise ArgumentError, 'HTTP redirect too deep' if limit == 0
+      
+        uri = URI.parse(uri_str)
+        request = Net::HTTP::Get.new(uri.request_uri)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        
+        response = http.request(request)
+
+        case response
+        when Net::HTTPSuccess
+          response
+        when Net::HTTPRedirection
+          fetch(response['location'], limit - 1)
+        else
+          response.value
+        end
+      end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
   post "papers/create"
   post "papers/upload"
   post "search/get_xml"
-  
+  get "translate", to: "translate#get"
+  post "translate", to: "translate#set"
 end

--- a/spec/controllers/translate_controller_spec.rb
+++ b/spec/controllers/translate_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TranslateController, type: :controller do
+
+end


### PR DESCRIPTION
## Change
### Before
- 今までは論文を取得したタイミングでGoogle Translate APIを叩き翻訳した上でフロントにデータを投げていた。

### After
- これからは論文を取得したタイミングでは翻訳処理をせず、英語データのままフロントに渡す。
- フロント側で翻訳データが必要かを判断し、Rails経由で翻訳APIを叩いて翻訳データを取得する。
- 翻訳データを取得したタイミングでデータベースに翻訳結果を保存し、翻訳APIを叩く回数を削減する。

### Good Point
- レスポンスが高速化する。
- 無駄にAPIを叩かなくて良い。
- フロント側が見ていて気持ち良い。