### PR TITLE
画像キャプションの翻訳をする

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.rb]
+tab_width = 4

--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -5,11 +5,12 @@ class FiguresController < ApplicationController
     def translate
         figure = Figure.find(translate_params[:id])
         text = figure.caption
-        uri_str = "https://script.google.com/macros/s/AKfycbxCeACoPPfC8stClMomoRepp36ytKFT7lkQ8CkFy5bMwd0jiDQ/exec?text=#{text}"
-        response = fetch(uri_str)
+        unless text.nil? then
+            uri_str = "https://script.google.com/macros/s/AKfycbxCeACoPPfC8stClMomoRepp36ytKFT7lkQ8CkFy5bMwd0jiDQ/exec?text=#{text}"
+            response = fetch(uri_str)
 
-        figure.update!(caption_ja: JSON.parse(response.body)["text"])
-
+            figure.update!(caption_ja: JSON.parse(response.body)["text"])
+        else
         render :json => figure
     end
 

--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -1,0 +1,43 @@
+require 'net/http'
+require 'uri'
+
+class FiguresController < ApplicationController
+    def translate
+        figure = Figure.find(translate_params[:id])
+        text = figure.caption
+        uri_str = "https://script.google.com/macros/s/AKfycbxCeACoPPfC8stClMomoRepp36ytKFT7lkQ8CkFy5bMwd0jiDQ/exec?text=#{text}"
+        response = fetch(uri_str)
+
+        figure.update!(caption_ja: JSON.parse(response.body)["text"])
+
+        render :json => figure
+    end
+
+    private
+    def translate_params
+        params.permit(:id) 
+    end
+
+    def fetch(uri_str, limit = 10)
+        # You should choose better exception.
+        raise ArgumentError, 'HTTP redirect too deep' if limit == 0
+      
+        uri = URI.parse(uri_str)
+        request = Net::HTTP::Get.new(uri.request_uri)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        
+        response = http.request(request)
+
+        case response
+        when Net::HTTPSuccess
+          response
+        when Net::HTTPRedirection
+          fetch(response['location'], limit - 1)
+        else
+          response.value
+        end
+    end
+end

--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -10,7 +10,7 @@ class FiguresController < ApplicationController
             response = fetch(uri_str)
 
             figure.update!(caption_ja: JSON.parse(response.body)["text"])
-        else
+        end
         render :json => figure
     end
 

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -71,12 +71,12 @@ class PapersController < ApplicationController
     
         figure = paper.figures.create(figure: params[:figure])
     
-        figure.explanation = params[:explanation]
+        figure.caption = params[:explanation]
     
         figure.save!
     
         render json: {
-            explanation: figure.explanation,
+            caption: figure.caption,
             figure: figure.figure.url
         }
       end

--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -1,4 +1,10 @@
 class Figure < ApplicationRecord
     belongs_to :paper
     mount_uploader :figure, PaperImageUploader
+
+    # 非推奨
+    # ToDo: フロントが対応次第削除する
+    def explanation
+        self.caption
+    end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,16 +1,23 @@
 CarrierWave.configure do |config|
-    # if Rails.env.development? or Rails.env.test?
-    #   config.asset_host = 'http://localhost:3000'
-    # end
-  
-
-    config.fog_credentials = {
-      provider: 'AWS',
-      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-      region: ENV['AWS_REGION']
-    }
-  
-    config.fog_directory  = ENV['AWS_S3_BUCKET']
-    config.cache_storage = :fog
+    if Rails.env.development?                                                                                                                   
+        CarrierWave.configure do |config|
+            config.asset_host = 'http://localhost:3000'
+        end 
+      elsif Rails.env.test?
+        CarrierWave.configure do |config|
+            config.asset_host = 'http://localhost:3000'
+        end 
+      else
+        CarrierWave.configure do |config|
+            config.fog_credentials = {
+                provider: 'AWS',
+                aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+                region: ENV['AWS_REGION']
+              }
+            
+              config.fog_directory  = ENV['AWS_S3_BUCKET']
+              config.cache_storage = :fog
+        end 
+      end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   get "translate", to: "translate#get"
   post "translate", to: "translate#set"
   post "papers/get_figure"
+  post "figure/:id/translate", to: "figures#translate"
 end

--- a/db/migrate/20200121141524_rename_explanation_to_caption.rb
+++ b/db/migrate/20200121141524_rename_explanation_to_caption.rb
@@ -1,0 +1,6 @@
+class RenameExplanationToCaption < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :figures, :explanation, :caption
+    add_column :figures, :caption_ja, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_18_045149) do
+ActiveRecord::Schema.define(version: 2020_01_21_141524) do
 
   create_table "authors", force: :cascade do |t|
     t.string "name"
@@ -20,10 +20,11 @@ ActiveRecord::Schema.define(version: 2019_12_18_045149) do
 
   create_table "figures", force: :cascade do |t|
     t.string "figure"
-    t.text "explanation"
+    t.text "caption"
     t.integer "paper_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "caption_ja"
     t.index ["paper_id"], name: "index_figures_on_paper_id"
   end
 
@@ -66,6 +67,32 @@ ActiveRecord::Schema.define(version: 2019_12_18_045149) do
     t.integer "cited_count"
     t.text "arxiv_id"
     t.integer "analized", default: 0
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "name"
+    t.string "nickname"
+    t.string "image"
+    t.string "email"
+    t.text "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+    t.index [nil], name: "index_users_on_confirmation_token", unique: true
   end
 
 end

--- a/spec/controllers/figures_controller_spec.rb
+++ b/spec/controllers/figures_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FiguresController, type: :controller do
+
+end

--- a/spec/factories/figures.rb
+++ b/spec/factories/figures.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :figure do
     figure { "MyString" }
-    explanation { "MyString" }
+    caption { "MyString" }
     references { "" }
   end
 end


### PR DESCRIPTION
## Feature ✨ 
- 画像キャプションの翻訳をする
    - `/figure/:id/translate` に POST するとキャプションを翻訳し、 Figure オブジェクトを返す

## Fix 🔧 
- ローカル環境で画像のアップロードができないバグを修正
    - fog の設定が本番環境の設定のみになっていたので、開発環境での設定を追記

## Refactor 💅 
- .editorconfig を設定し、タブ幅を4に固定