### PR TITLE
検索精度の圧倒的向上

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,10 +6,11 @@ class SearchController < ApplicationController
     def get_xml
         # 検索ワードのエスケープ処理
         search_word = URI.encode_www_form_component(params['search_word'])
+        hyphen_removed_search_word = search_word.gsub('-', ' ');
         page = params[:page].to_i || 0
     
         # arXiv APIのエンドポイントURLを構築
-        url = URI.parse("http://export.arxiv.org/api/query?search_query=%28abs:%22#{search_word}%22+OR+au:%22#{search_word}%22%29&start=#{page*30}&max_results=30&sortBy=lastUpdatedDate&sortOrder=descending")
+        url = URI.parse("http://export.arxiv.org/api/query?search_query=\"#{search_word}\"OR\"#{hyphen_removed_search_word}\"&start=#{page*30}&max_results=30&sortBy=lastUpdatedDate&sortOrder=descending")
 
         # arXiv APIを叩いてデータを取得する
         res = Net::HTTP.get_response(url) ## 生のレスポンス


### PR DESCRIPTION
## Updates 🆙 

- 複数ワードを用いた検索に対応
- デフォルトで全項目を検索するようにする
    - アブストや著者名に限らず検索するようにした
- ハイフンを含む検索ワードは著しく性能が落ちるので、検索ワードにハイフンを含む場合はハイフンをスペースに置換したワードもOR検索する
    - ハイフンを含む場合におなぜ検索精度が下がるのかは謎

## ScreenShots 📱 

**`self-driving` で検索時**

| Before | After |
|:----:|:----:|
| ![image](https://user-images.githubusercontent.com/6907421/73237069-d2491380-41d7-11ea-836c-95da8e7bab54.png) | ![image](https://user-images.githubusercontent.com/6907421/73237140-06243900-41d8-11ea-9e15-20bf4ec96c12.png) |